### PR TITLE
Fix visual selection

### DIFF
--- a/css/workspace_nav.css
+++ b/css/workspace_nav.css
@@ -1,3 +1,3 @@
-.workspace .nav-selected-focused > .tree-item > p {background: var(result-bg); }
+.workspace .nav-selected-focused > .tree-item > p {background: #505D6B; } /* Previously var(result-bg) */
 
-.workspace .nav-selected-unfocused > .tree-item > p {background: var(dark-highlight-bg); }
+.workspace .nav-selected-unfocused > .tree-item > p {background: #666; } /* Previously var(dark-highlight-bg) */


### PR DESCRIPTION
The use of Light Table skin variables appears to not work in the plugin, which was causing the background to not be set.

This fix simply uses the corresponding hex color value instead.